### PR TITLE
Enable chat parsing via bot manager

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -1,6 +1,8 @@
 from collections import deque
 from functools import wraps
 from telethon import TelegramClient, events
+from telethon.tl.functions.messages import GetDialogsRequest
+from telethon.tl.types import InputPeerEmpty
 import os
 import asyncio
 from defunc import getoptions
@@ -19,6 +21,7 @@ async def get_sessions():
 
 # Храним состояние аккаунтов: ok или текст ошибки
 account_status = {}
+available_chats = []
 
 
 def notify_errors(func):
@@ -38,8 +41,12 @@ async def start(event):
         '/set_message <текст> - текст рассылки\n'
         '/add_user <username> - добавить пользователя\n'
         '/clear_users - очистить список\n'
+        '/users - файл с пользователями\n'
+        '/chats - список чатов для парсинга\n'
+        '/parse <номер> - спарсить чат\n'
         '/test <username> - тестовая отправка\n'
-        '/send - запустить рассылку'
+        '/send - запустить рассылку\n'
+        '/end - лог рассылки'
     )
 
 @bot.on(events.NewMessage(pattern='/stats'))
@@ -91,9 +98,111 @@ async def clear_users(event):
 @notify_errors
 async def send_users_file(event):
     if os.path.exists('usernames.txt'):
-        await event.respond(file='usernames.txt')
+        if os.path.getsize('usernames.txt') > 0:
+            await event.respond(file='usernames.txt')
+        else:
+            await event.respond('Файл usernames.txt пуст')
     else:
         await event.respond('Файл usernames.txt не найден')
+
+
+@bot.on(events.NewMessage(pattern='/chats'))
+@notify_errors
+async def list_chats(event):
+    sessions = await get_sessions()
+    if not sessions:
+        await event.respond('Нет аккаунтов')
+        return
+    client = TelegramClient(sessions[0], api_id, api_hash)
+    await client.start()
+    result = await client(
+        GetDialogsRequest(
+            offset_date=None,
+            offset_id=0,
+            offset_peer=InputPeerEmpty(),
+            limit=200,
+            hash=0,
+        )
+    )
+    chats = result.chats
+    groups = []
+    for chat in chats:
+        try:
+            if chat.megagroup:
+                groups.append(chat)
+        except AttributeError:
+            continue
+    await client.disconnect()
+    if not groups:
+        await event.respond('Нет доступных групп')
+        return
+    global available_chats
+    available_chats = groups
+    lines = [f'{i} - {g.title}' for i, g in enumerate(groups)]
+    await event.respond('Доступные чаты:\n' + '\n'.join(lines) + '\nИспользуйте /parse <номер>')
+
+
+@bot.on(events.NewMessage(pattern='/parse'))
+@notify_errors
+async def parse_command(event):
+    parts = event.raw_text.split()
+    if len(parts) < 2:
+        await event.respond('Использование: /parse номер')
+        return
+    if not available_chats:
+        await event.respond('Сначала выполните /chats')
+        return
+    index = parts[1]
+    if index == 'all':
+        targets = available_chats
+    else:
+        try:
+            targets = [available_chats[int(index)]]
+        except (ValueError, IndexError):
+            await event.respond('Неверный номер чата')
+            return
+    sessions = await get_sessions()
+    if not sessions:
+        await event.respond('Нет аккаунтов')
+        return
+    client = TelegramClient(sessions[0], api_id, api_hash)
+    await client.start()
+    opts = getoptions()
+    parse_ids = opts[2].strip() == 'True'
+    parse_names = opts[3].strip() == 'True'
+    existing_names = set()
+    if parse_names and os.path.exists('usernames.txt'):
+        with open('usernames.txt') as f:
+            existing_names = {u.strip() for u in f if u.strip()}
+        names_file = open('usernames.txt', 'a')
+    else:
+        names_file = None
+    existing_ids = set()
+    if parse_ids and os.path.exists('userids.txt'):
+        with open('userids.txt') as f:
+            existing_ids = {u.strip() for u in f if u.strip()}
+        ids_file = open('userids.txt', 'a')
+    else:
+        ids_file = None
+    for chat in targets:
+        participants = await client.get_participants(chat)
+        for user in participants:
+            if parse_names and user.username and 'bot' not in user.username.lower():
+                uname = '@' + user.username
+                if uname not in existing_names:
+                    names_file.write(uname + '\n')
+                    existing_names.add(uname)
+            if parse_ids:
+                uid = str(user.id)
+                if uid not in existing_ids:
+                    ids_file.write(uid + '\n')
+                    existing_ids.add(uid)
+    if names_file:
+        names_file.close()
+    if ids_file:
+        ids_file.close()
+    await client.disconnect()
+    await event.respond('Спаршено')
 
 @bot.on(events.NewMessage(pattern='/test'))
 @notify_errors


### PR DESCRIPTION
## Summary
- add /chats and /parse commands to list and parse group members
- update start message with new commands including /users
- handle empty usernames file to avoid FilePartsInvalidError

## Testing
- `python -m py_compile bot_manager.py defunc.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c00a79d4708329bdb7b561d4d3daba