### PR TITLE
Ignore manager bot session file when listing user sessions

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -17,7 +17,11 @@ bot_token = options[4].strip()
 bot = TelegramClient('manager_bot', api_id, api_hash).start(bot_token=bot_token)
 
 async def get_sessions():
-    return [f for f in os.listdir('.') if f.endswith('.session')]
+    return [
+        f
+        for f in os.listdir('.')
+        if f.endswith('.session') and f != 'manager_bot.session'
+    ]
 
 # Храним состояние аккаунтов: ok или текст ошибки
 account_status = {}


### PR DESCRIPTION
## Summary
- avoid database locking by excluding the manager bot's session file from user session discovery

## Testing
- `python -m py_compile bot_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0136687dc83298d41ef9383e3893e