### PR TITLE
Handle database locking in session operations

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -26,6 +26,8 @@ async def get_sessions():
 # Храним состояние аккаунтов: ok или текст ошибки
 account_status = {}
 available_chats = []
+# Глобальная блокировка для исключения одновременного доступа к сессиям
+session_lock = asyncio.Lock()
 
 
 def notify_errors(func):
@@ -113,43 +115,40 @@ async def send_users_file(event):
 @bot.on(events.NewMessage(pattern='/chats'))
 @notify_errors
 async def list_chats(event):
-    sessions = await get_sessions()
-    if not sessions:
-        await event.respond('Нет аккаунтов')
-        return
-    groups = []
-    chat_map = []
-    seen_ids = set()
-    for session in sessions:
-        client = TelegramClient(session, api_id, api_hash)
-        try:
-            await client.start()
-            result = await client(
-                GetDialogsRequest(
-                    offset_date=None,
-                    offset_id=0,
-                    offset_peer=InputPeerEmpty(),
-                    limit=200,
-                    hash=0,
+    async with session_lock:
+        sessions = await get_sessions()
+        if not sessions:
+            await event.respond('Нет аккаунтов')
+            return
+        groups = []
+        chat_map = []
+        seen_ids = set()
+        for session in sessions:
+            async with TelegramClient(session, api_id, api_hash) as client:
+                result = await client(
+                    GetDialogsRequest(
+                        offset_date=None,
+                        offset_id=0,
+                        offset_peer=InputPeerEmpty(),
+                        limit=200,
+                        hash=0,
+                    )
                 )
-            )
-            for chat in result.chats:
-                try:
-                    if chat.megagroup and chat.id not in seen_ids:
-                        seen_ids.add(chat.id)
-                        groups.append(f"{chat.title} ({session})")
-                        chat_map.append((session, chat))
-                except AttributeError:
-                    continue
-        finally:
-            await client.disconnect()
-    if not chat_map:
-        await event.respond('Нет доступных групп')
-        return
-    global available_chats
-    available_chats = chat_map
-    lines = [f'{i} - {title}' for i, title in enumerate(groups)]
-    await event.respond('Доступные чаты:\n' + '\n'.join(lines) + '\nИспользуйте /parse <номер>')
+                for chat in result.chats:
+                    try:
+                        if chat.megagroup and chat.id not in seen_ids:
+                            seen_ids.add(chat.id)
+                            groups.append(f"{chat.title} ({session})")
+                            chat_map.append((session, chat))
+                    except AttributeError:
+                        continue
+        if not chat_map:
+            await event.respond('Нет доступных групп')
+            return
+        global available_chats
+        available_chats = chat_map
+        lines = [f'{i} - {title}' for i, title in enumerate(groups)]
+        await event.respond('Доступные чаты:\n' + '\n'.join(lines) + '\nИспользуйте /parse <номер>')
 
 
 @bot.on(events.NewMessage(pattern='/parse'))
@@ -171,45 +170,42 @@ async def parse_command(event):
         except (ValueError, IndexError):
             await event.respond('Неверный номер чата')
             return
-    opts = getoptions()
-    parse_ids = opts[2].strip() == 'True'
-    parse_names = opts[3].strip() == 'True'
-    existing_names = set()
-    if parse_names and os.path.exists('usernames.txt'):
-        with open('usernames.txt') as f:
-            existing_names = {u.strip() for u in f if u.strip()}
-        names_file = open('usernames.txt', 'a')
-    else:
-        names_file = None
-    existing_ids = set()
-    if parse_ids and os.path.exists('userids.txt'):
-        with open('userids.txt') as f:
-            existing_ids = {u.strip() for u in f if u.strip()}
-        ids_file = open('userids.txt', 'a')
-    else:
-        ids_file = None
-    for session, chat in targets:
-        client = TelegramClient(session, api_id, api_hash)
-        try:
-            await client.start()
-            participants = await client.get_participants(chat)
-            for user in participants:
-                if parse_names and user.username and 'bot' not in user.username.lower():
-                    uname = '@' + user.username
-                    if uname not in existing_names:
-                        names_file.write(uname + '\n')
-                        existing_names.add(uname)
-                if parse_ids:
-                    uid = str(user.id)
-                    if uid not in existing_ids:
-                        ids_file.write(uid + '\n')
-                        existing_ids.add(uid)
-        finally:
-            await client.disconnect()
-    if names_file:
-        names_file.close()
-    if ids_file:
-        ids_file.close()
+    async with session_lock:
+        opts = getoptions()
+        parse_ids = opts[2].strip() == 'True'
+        parse_names = opts[3].strip() == 'True'
+        existing_names = set()
+        if parse_names and os.path.exists('usernames.txt'):
+            with open('usernames.txt') as f:
+                existing_names = {u.strip() for u in f if u.strip()}
+            names_file = open('usernames.txt', 'a')
+        else:
+            names_file = None
+        existing_ids = set()
+        if parse_ids and os.path.exists('userids.txt'):
+            with open('userids.txt') as f:
+                existing_ids = {u.strip() for u in f if u.strip()}
+            ids_file = open('userids.txt', 'a')
+        else:
+            ids_file = None
+        for session, chat in targets:
+            async with TelegramClient(session, api_id, api_hash) as client:
+                participants = await client.get_participants(chat)
+                for user in participants:
+                    if parse_names and user.username and 'bot' not in user.username.lower():
+                        uname = '@' + user.username
+                        if uname not in existing_names:
+                            names_file.write(uname + '\n')
+                            existing_names.add(uname)
+                    if parse_ids:
+                        uid = str(user.id)
+                        if uid not in existing_ids:
+                            ids_file.write(uid + '\n')
+                            existing_ids.add(uid)
+        if names_file:
+            names_file.close()
+        if ids_file:
+            ids_file.close()
     await event.respond('Спаршено')
 
 @bot.on(events.NewMessage(pattern='/test'))
@@ -222,16 +218,15 @@ async def test(event):
     if not os.path.exists(MESSAGE_FILE):
         await event.respond('Сначала задайте текст через /set_message')
         return
-    sessions = await get_sessions()
-    if not sessions:
-        await event.respond('Нет аккаунтов')
-        return
-    with open(MESSAGE_FILE) as f:
-        msg = f.read()
-    client = TelegramClient(sessions[0], api_id, api_hash)
-    await client.start()
-    await client.send_message(parts[1], msg)
-    await client.disconnect()
+    async with session_lock:
+        sessions = await get_sessions()
+        if not sessions:
+            await event.respond('Нет аккаунтов')
+            return
+        with open(MESSAGE_FILE) as f:
+            msg = f.read()
+        async with TelegramClient(sessions[0], api_id, api_hash) as client:
+            await client.send_message(parts[1], msg)
     await event.respond('Отправлено')
 
 @bot.on(events.NewMessage(pattern='/send'))
@@ -248,65 +243,66 @@ async def send_all(event):
     if not users:
         await event.respond('Нет пользователей для рассылки')
         return
-    sessions = await get_sessions()
-    if not sessions:
-        await event.respond('Нет аккаунтов')
-        return
-    with open(MESSAGE_FILE) as f:
-        msg = f.read()
+    async with session_lock:
+        sessions = await get_sessions()
+        if not sessions:
+            await event.respond('Нет аккаунтов')
+            return
+        with open(MESSAGE_FILE) as f:
+            msg = f.read()
 
-    clients = {}
-    account_status.clear()
-    for session in sessions:
-        client = TelegramClient(session, api_id, api_hash)
-        try:
-            await client.start()
-            clients[session] = client
-            account_status[session] = 'ok'
-        except Exception as e:
-            account_status[session] = f'error: {type(e).__name__}'
-
-    if not clients:
-        await event.respond('Нет рабочих аккаунтов')
-        return
-
-    queue = deque(clients.items())
-    failed_users = []
-    log_lines = []
-
-    for user in users:
-        delivered = False
-        attempts = 0
-        error_text = ''
-        while queue and attempts < len(queue):
-            session, client = queue[0]
+        clients = {}
+        account_status.clear()
+        for session in sessions:
+            client = TelegramClient(session, api_id, api_hash)
             try:
-                await client.send_message(user, msg)
-                queue.rotate(-1)
-                delivered = True
-                log_lines.append(f'{user}: delivered')
-                await asyncio.sleep(1)
-                break
+                await client.start()
+                clients[session] = client
+                account_status[session] = 'ok'
             except Exception as e:
-                await client.disconnect()
                 account_status[session] = f'error: {type(e).__name__}'
-                queue.popleft()
-                attempts += 1
-                error_text = f'{type(e).__name__}: {e}'
-        if not delivered:
-            failed_users.append(user)
-            log_lines.append(f'{user}: {error_text or "failed"}')
 
-    for _, client in queue:
-        await client.disconnect()
+        if not clients:
+            await event.respond('Нет рабочих аккаунтов')
+            return
 
-    with open('send_log.txt', 'w') as log_file:
-        log_file.write('\n'.join(log_lines))
+        queue = deque(clients.items())
+        failed_users = []
+        log_lines = []
 
-    if failed_users:
-        await event.respond('Не доставлено: ' + ', '.join(failed_users))
-    else:
-        await event.respond('Рассылка завершена')
+        for user in users:
+            delivered = False
+            attempts = 0
+            error_text = ''
+            while queue and attempts < len(queue):
+                session, client = queue[0]
+                try:
+                    await client.send_message(user, msg)
+                    queue.rotate(-1)
+                    delivered = True
+                    log_lines.append(f'{user}: delivered')
+                    await asyncio.sleep(1)
+                    break
+                except Exception as e:
+                    await client.disconnect()
+                    account_status[session] = f'error: {type(e).__name__}'
+                    queue.popleft()
+                    attempts += 1
+                    error_text = f'{type(e).__name__}: {e}'
+            if not delivered:
+                failed_users.append(user)
+                log_lines.append(f'{user}: {error_text or "failed"}')
+
+        for _, client in queue:
+            await client.disconnect()
+
+        with open('send_log.txt', 'w') as log_file:
+            log_file.write('\n'.join(log_lines))
+
+        if failed_users:
+            await event.respond('Не доставлено: ' + ', '.join(failed_users))
+        else:
+            await event.respond('Рассылка завершена')
 
 @bot.on(events.NewMessage(pattern='/end'))
 @notify_errors


### PR DESCRIPTION
## Summary
- Serialize access to Telegram session files with a global asyncio lock
- Use async context managers for TelegramClient to ensure connections close properly
- Apply lock in chat listing, parsing, testing and sending commands to prevent `database is locked` errors

## Testing
- `python -m py_compile bot_manager.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0197edb8083299145d9a364aab48b