### PR TITLE
Add per-session proxy management and status tracking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyaes==1.6.1
 pyasn1==0.6.1
 rsa==4.9.1
 Telethon==1.40.0
+pysocks==1.7.1


### PR DESCRIPTION
## Summary
- map proxies to sessions via `proxies.txt` and expose helper utilities
- manage proxy assignments with `/add_proxy`, `/ping_proxy`, and enhanced `/sessions` output
- route all session activity through assigned proxies and track proxy health

## Testing
- `python -m py_compile bot_manager.py`
- `python -m py_compile main.py defunc.py`


------
https://chatgpt.com/codex/tasks/task_e_68c038c01dc083299bc3309c728b277c