### PR TITLE
Fix add_zip conversation in Telegram bot

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -307,12 +307,11 @@ async def add_zip(event):
     if event.message.file and event.message.file.name.endswith('.zip'):
         await process(event.message, event.respond)
         return
-
-    await event.respond('Отправьте .zip архив с сессиями')
     async with bot.conversation(event.chat_id, timeout=60) as conv:
+        await conv.send_message('Отправьте .zip архив с сессиями')
         response = await conv.get_response()
-        if response.message.file and response.message.file.name.endswith('.zip'):
-            await process(response.message, conv.send_message)
+        if response.file and response.file.name.endswith('.zip'):
+            await process(response, conv.send_message)
         else:
             await conv.send_message('Ошибка: архив не получен')
 


### PR DESCRIPTION
## Summary
- fix add_zip handler to prompt within conversation and correctly process response

## Testing
- `python -m py_compile bot_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c06ee47ce08329925395fafa736c38