### PR TITLE
Log errors to console instead of Telegram chat

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -206,7 +206,8 @@ def notify_errors(func):
         try:
             return await func(event, *args, **kwargs)
         except Exception as e:
-            await event.respond(f'Ошибка: {type(e).__name__}: {e}')
+            print(f'Ошибка: {type(e).__name__}: {e}')
+            await event.respond('Произошла ошибка. Подробности в консоли.')
     return wrapper
 
 @bot.on(events.NewMessage(pattern='/start'))
@@ -352,7 +353,8 @@ async def add_session(event):
             account_status[f'{session_name}.session'] = 'ok'
             await conv.send_message('Сессия добавлена')
         except Exception as e:
-            await conv.send_message(f'Ошибка: {e}')
+            print(f'Ошибка: {e}')
+            await conv.send_message('Произошла ошибка. Подробности в консоли.')
         finally:
             await client.disconnect()
 


### PR DESCRIPTION
## Summary
- Log exceptions to console instead of sending full error details to Telegram chats
- Add generic chat notifications when session addition or command handlers encounter errors

## Testing
- `python -m py_compile bot_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0864a24848329bb64388148fbca38