### PR TITLE
fix: make proxy parsing compatible with various Telethon versions

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -128,57 +128,48 @@ session_lock = asyncio.Lock()
 
 
 def parse_proxy(proxy_str):
-    """Convert a textual proxy definition into a dictionary.
+    """Convert a textual proxy string into Telethon's internal tuple.
 
-    ``proxy_str`` may be in any of the following common forms::
+    Supports the following common forms::
 
         host:port
         host:port:user:pass
         user:pass@host:port
         socks5://user:pass@host:port
 
-    The implementation relies on :func:`urllib.parse.urlparse` to deal with
-    corner cases such as IPv6 addresses or credentials containing ``:``.
-    Only SOCKS5 proxies are supported, which matches the expectations of the
-    rest of the project.  The returned mapping intentionally exposes just the
-    fields consumed by Telethon; omitting the ``rdns`` flag keeps the result
-    to five items and avoids ``ValueError: too many values to unpack`` errors
-    observed with the previous implementation.
+    The return value is the exact tuple produced by
+    :func:`telethon.network.connection.connection.Connection._parse_proxy` for
+    the given parameters, ensuring compatibility with both new and old
+    Telethon versions that expect either five or six positional items.
     """
 
     from urllib.parse import urlparse
+    from telethon.network.connection.connection import Connection
 
     # Allow ``ip:port:user:pass`` format used by some proxy providers.
     if '@' not in proxy_str and proxy_str.count(':') == 3:
         host, port, username, password = proxy_str.split(':', 3)
-        if not host or not port:
-            raise ValueError('Некорректный формат прокси')
-        try:
-            port = int(port)
-        except ValueError:
-            raise ValueError('Некорректный порт в прокси')
-        return {
-            'proxy_type': socks.SOCKS5,
-            'addr': host,
-            'port': port,
-            'username': username,
-            'password': password,
-        }
+    else:
+        if '://' not in proxy_str:
+            proxy_str = 'socks5://' + proxy_str
+        parsed = urlparse(proxy_str)
+        host = parsed.hostname
+        port = parsed.port
+        username = parsed.username
+        password = parsed.password
 
-    if '://' not in proxy_str:
-        proxy_str = 'socks5://' + proxy_str
-
-    parsed = urlparse(proxy_str)
-    if not parsed.hostname or not parsed.port:
+    if not host or not port:
         raise ValueError('Некорректный формат прокси')
+    try:
+        port = int(port)
+    except ValueError:
+        raise ValueError('Некорректный порт в прокси')
 
-    return {
-        'proxy_type': socks.SOCKS5,
-        'addr': parsed.hostname,
-        'port': parsed.port,
-        'username': parsed.username,
-        'password': parsed.password,
-    }
+    # Delegate to Telethon's own helper which returns a tuple with the
+    # appropriate number of items for the installed version.
+    return Connection._parse_proxy(
+        socks.SOCKS5, host, port, username=username, password=password
+    )
 
 
 async def get_proxy_map():


### PR DESCRIPTION
## Summary
- use Telethon's internal `_parse_proxy` helper to produce version-safe proxy tuples

## Testing
- `python -m py_compile bot_manager.py`
- `python -m py_compile defunc.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c08337f8dc8329911c126e518169f7