### PR TITLE
feat: extend reply wait to 24h and allow parallel send_reply

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -76,7 +76,7 @@ def get_user_lists():
     )
 
 
-async def reply_watcher(client, usernames, msg2, duration=3600):
+async def reply_watcher(client, usernames, msg2, duration=86400):
     start_time = datetime.now(timezone.utc)
 
     async def handler(event):
@@ -798,9 +798,8 @@ async def send_reply(event):
     if not users:
         await event.respond('Нет пользователей для рассылки')
         return
-    for task in reply_tasks:
-        task.cancel()
-    reply_tasks.clear()
+    # Remove completed reply tasks but keep active ones
+    reply_tasks[:] = [t for t in reply_tasks if not t.done()]
 
     async with session_lock:
         proxy_map = await get_proxy_map()


### PR DESCRIPTION
## Summary
- increase reply watcher duration to 24 hours
- keep previous reply tasks running and clean up completed ones

## Testing
- `python -m py_compile bot_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68c09508d1948329b957bd0a9527eaf4