### PR TITLE
Add delay and typing indicator before reply

### DIFF
--- a/bot_manager.py
+++ b/bot_manager.py
@@ -85,6 +85,9 @@ async def reply_watcher(client, usernames, msg2, duration=86400):
         sender = await event.get_sender()
         username = getattr(sender, 'username', None)
         if username and username.lower() in usernames:
+            await asyncio.sleep(3)
+            async with event.client.action(event.chat_id, 'typing'):
+                await asyncio.sleep(7)
             await event.reply(msg2)
             usernames.remove(username.lower())
 


### PR DESCRIPTION
## Summary
- Delay second message in reply watcher by 10 seconds
- Display typing indicator after 3 seconds so the user sees it

## Testing
- `python -m py_compile bot_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68c09af3d4d4832996e6cc2b953e328a